### PR TITLE
feat: Add UI for diagnostics

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -36,6 +36,7 @@ require('lazy').setup({
   require 'plugins.sleuth',
   require 'plugins.telescope',
   require 'plugins.treesitter',
+  require 'plugins.trouble',
   require 'plugins.which-key',
   require 'plugins.yanky',
 }, {

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -33,6 +33,7 @@
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "todo-comments.nvim": { "branch": "main", "commit": "ae0a2afb47cf7395dc400e5dc4e05274bf4fb9e0" },
   "tokyonight.nvim": { "branch": "main", "commit": "817bb6ffff1b9ce72cdd45d9fcfa8c9cd1ad3839" },
+  "trouble.nvim": { "branch": "main", "commit": "6efc446226679fda0547c0fd6a7892fd5f5b15d8" },
   "vim-sleuth": { "branch": "master", "commit": "be69bff86754b1aa5adcbb527d7fcd1635a84080" },
   "which-key.nvim": { "branch": "main", "commit": "fb070344402cfc662299d9914f5546d840a22126" },
   "yanky.nvim": { "branch": "main", "commit": "73215b77d22ebb179cef98e7e1235825431d10e4" }

--- a/nvim/lua/keymaps.lua
+++ b/nvim/lua/keymaps.lua
@@ -4,9 +4,6 @@
 -- Clear highlights on search when pressing <Esc> in normal mode
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
--- Diagnostic keymaps
-vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'open diagnostic Quickfix list' })
-
 -- Disable arrow keys in normal mode
 vim.keymap.set('n', '<left>', '<cmd>echo "Use h to move!"<CR>')
 vim.keymap.set('n', '<right>', '<cmd>echo "Use l to move!"<CR>')

--- a/nvim/lua/plugins/comments.lua
+++ b/nvim/lua/plugins/comments.lua
@@ -4,4 +4,16 @@ return {
   event = 'VimEnter',
   dependencies = { 'nvim-lua/plenary.nvim' },
   opts = { signs = false },
+  keys = {
+    {
+      '<leader>ft',
+      ':TodoTelescope<CR>',
+      desc = 'Comments: Find Todos',
+    },
+    {
+      '<leader>xt',
+      ':TodoQuickFix<CR>',
+      desc = 'Comments: Todo list',
+    },
+  },
 }

--- a/nvim/lua/plugins/trouble.lua
+++ b/nvim/lua/plugins/trouble.lua
@@ -1,0 +1,38 @@
+-- Integrates improved UI for quickfixes, diagnostics and TODOs
+return {
+  'folke/trouble.nvim',
+  opts = {},
+  cmd = 'Trouble',
+  keys = {
+    {
+      '<leader>xd',
+      '<cmd>Trouble diagnostics toggle<cr>',
+      desc = 'Trouble: Diagnostics',
+    },
+    {
+      '<leader>xD',
+      '<cmd>Trouble diagnostics toggle filter.buf=0<cr>',
+      desc = 'Trouble: Diagnostics buffer',
+    },
+    {
+      '<leader>cs',
+      '<cmd>Trouble symbols toggle focus=false<cr>',
+      desc = 'Trouble: Code Symbols',
+    },
+    {
+      '<leader>cl',
+      '<cmd>Trouble lsp toggle focus=false win.position=right<cr>',
+      desc = 'Trouble: Code LSP references',
+    },
+    {
+      '<leader>xL',
+      '<cmd>Trouble loclist toggle<cr>',
+      desc = 'Trouble: Location list',
+    },
+    {
+      '<leader>xQ',
+      '<cmd>Trouble qflist toggle<cr>',
+      desc = 'Trouble: Quickfix list',
+    },
+  },
+}

--- a/nvim/lua/plugins/which-key.lua
+++ b/nvim/lua/plugins/which-key.lua
@@ -123,6 +123,7 @@ return {
       { '<leader>w', group = 'Workspace', icon = { icon = '󰙅', color = 'yellow' } },
       { '<leader>t', group = 'Toggle' },
       { '<leader>h', group = 'Hunk', mode = { 'n', 'v' }, icon = { icon = '󰊢', color = 'orange' } },
+      { '<leader>x', group = 'Trouble', icon = { icon = '󰙅', color = 'red' } },
     },
   },
   keys = {


### PR DESCRIPTION
Integrates `trouble.nvim` for providing a diagnostics listing UI

Closes #7 - functionality not completely matching requirements, but the plugins don't support specifying a single buffer to act upon, so both the `trouble.nvim` and the `telescope.nvim` integrations for todo-comments.nvim are global from the cwd.