### PR TITLE
feat: Add Alacritty and Tmux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !/alacritty
 !/nvim
 !/tmux
+/tmux/plugins
 
 # Misc. files
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Tools
 !/alacritty
 !/nvim
+!/tmux
 
 # Misc. files
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 !.gitignore
 !README.md
 
-# Neovim
+# Tools
+!/alacritty
 !/nvim
 
 # Misc. files

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -6,6 +6,7 @@ padding.x = 10
 padding.y = 10
 decorations = "None"
 dynamic_title = false
+option_as_alt = "OnlyLeft"
 
 [font]
 normal.family = "CaskaydiaMono Nerd Font"

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -6,3 +6,7 @@ padding.x = 10
 padding.y = 10
 decorations = "None"
 dynamic_title = false
+
+[font]
+normal.family = "CaskaydiaMono Nerd Font"
+size = 16

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,3 +1,8 @@
 [env]
 TERM = "xterm-256color"
 
+[window]
+padding.x = 10
+padding.y = 10
+decorations = "None"
+dynamic_title = false

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,0 +1,3 @@
+[env]
+TERM = "xterm-256color"
+

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,4 +1,7 @@
 import = [
+	# "~/.config/alacritty/themes/rose-pine.toml"
+	# "~/.config/alacritty/themes/rose-pine-dawn.toml"
+	"~/.config/alacritty/themes/rose-pine-moon.toml"
 ]
 
 [env]

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,3 +1,6 @@
+import = [
+]
+
 [env]
 TERM = "xterm-256color"
 

--- a/alacritty/themes/rose-pine-dawn.toml
+++ b/alacritty/themes/rose-pine-dawn.toml
@@ -1,0 +1,75 @@
+# Colors section of "Alacritty - TOML configuration file format"
+# https://github.com/alacritty/alacritty/blob/master/extra/man/alacritty.5.scd#colors
+
+[colors.primary]
+foreground = "#575279"
+background = "#faf4ed"
+dim_foreground = "#797593"
+bright_foreground = "#575279"
+
+[colors.cursor]
+text = "#575279"
+cursor = "#cecacd"
+
+[colors.vi_mode_cursor]
+text = "#575279"
+cursor = "#cecacd"
+
+[colors.search.matches]
+foreground = "#797593"
+background = "#f2e9e1"
+
+[colors.search.focused_match]
+foreground = "#faf4ed"
+background = "#d7827e"
+
+[colors.hints.start]
+foreground = "#797593"
+background = "#fffaf3"
+
+[colors.hints.end]
+foreground = "#9893a5"
+background = "#fffaf3"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.footer_bar]
+foreground = "#575279"
+background = "#fffaf3"
+
+[colors.selection]
+text = "#575279"
+background = "#dfdad9"
+
+[colors.normal]
+black = "#f2e9e1"
+red = "#b4637a"
+green = "#286983"
+yellow = "#ea9d34"
+blue = "#56949f"
+magenta = "#907aa9"
+cyan = "#d7827e"
+white = "#575279"
+
+[colors.bright]
+black = "#9893a5"
+red = "#b4637a"
+green = "#286983"
+yellow = "#ea9d34"
+blue = "#56949f"
+magenta = "#907aa9"
+cyan = "#d7827e"
+white = "#575279"
+
+[colors.dim]
+black = "#9893a5"
+red = "#b4637a"
+green = "#286983"
+yellow = "#ea9d34"
+blue = "#56949f"
+magenta = "#907aa9"
+cyan = "#d7827e"
+white = "#575279"
+

--- a/alacritty/themes/rose-pine-moon.toml
+++ b/alacritty/themes/rose-pine-moon.toml
@@ -1,0 +1,75 @@
+# Colors section of "Alacritty - TOML configuration file format"
+# https://github.com/alacritty/alacritty/blob/master/extra/man/alacritty.5.scd#colors
+
+[colors.primary]
+foreground = "#e0def4"
+background = "#232136"
+dim_foreground = "#908caa"
+bright_foreground = "#e0def4"
+
+[colors.cursor]
+text = "#e0def4"
+cursor = "#56526e"
+
+[colors.vi_mode_cursor]
+text = "#e0def4"
+cursor = "#56526e"
+
+[colors.search.matches]
+foreground = "#908caa"
+background = "#393552"
+
+[colors.search.focused_match]
+foreground = "#232136"
+background = "#ea9a97"
+
+[colors.hints.start]
+foreground = "#908caa"
+background = "#2a273f"
+
+[colors.hints.end]
+foreground = "#6e6a86"
+background = "#2a273f"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.footer_bar]
+foreground = "#e0def4"
+background = "#2a273f"
+
+[colors.selection]
+text = "#e0def4"
+background = "#44415a"
+
+[colors.normal]
+black = "#393552"
+red = "#eb6f92"
+green = "#3e8fb0"
+yellow = "#f6c177"
+blue = "#9ccfd8"
+magenta = "#c4a7e7"
+cyan = "#ea9a97"
+white = "#e0def4"
+
+[colors.bright]
+black = "#6e6a86"
+red = "#eb6f92"
+green = "#3e8fb0"
+yellow = "#f6c177"
+blue = "#9ccfd8"
+magenta = "#c4a7e7"
+cyan = "#ea9a97"
+white = "#e0def4"
+
+[colors.dim]
+black = "#6e6a86"
+red = "#eb6f92"
+green = "#3e8fb0"
+yellow = "#f6c177"
+blue = "#9ccfd8"
+magenta = "#c4a7e7"
+cyan = "#ea9a97"
+white = "#e0def4"
+

--- a/alacritty/themes/rose-pine.toml
+++ b/alacritty/themes/rose-pine.toml
@@ -1,0 +1,75 @@
+# Colors section of "Alacritty - TOML configuration file format"
+# https://github.com/alacritty/alacritty/blob/master/extra/man/alacritty.5.scd#colors
+
+[colors.primary]
+foreground = "#e0def4"
+background = "#191724"
+dim_foreground = "#908caa"
+bright_foreground = "#e0def4"
+
+[colors.cursor]
+text = "#e0def4"
+cursor = "#524f67"
+
+[colors.vi_mode_cursor]
+text = "#e0def4"
+cursor = "#524f67"
+
+[colors.search.matches]
+foreground = "#908caa"
+background = "#26233a"
+
+[colors.search.focused_match]
+foreground = "#191724"
+background = "#ebbcba"
+
+[colors.hints.start]
+foreground = "#908caa"
+background = "#1f1d2e"
+
+[colors.hints.end]
+foreground = "#6e6a86"
+background = "#1f1d2e"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.footer_bar]
+foreground = "#e0def4"
+background = "#1f1d2e"
+
+[colors.selection]
+text = "#e0def4"
+background = "#403d52"
+
+[colors.normal]
+black = "#26233a"
+red = "#eb6f92"
+green = "#31748f"
+yellow = "#f6c177"
+blue = "#9ccfd8"
+magenta = "#c4a7e7"
+cyan = "#ebbcba"
+white = "#e0def4"
+
+[colors.bright]
+black = "#6e6a86"
+red = "#eb6f92"
+green = "#31748f"
+yellow = "#f6c177"
+blue = "#9ccfd8"
+magenta = "#c4a7e7"
+cyan = "#ebbcba"
+white = "#e0def4"
+
+[colors.dim]
+black = "#6e6a86"
+red = "#eb6f92"
+green = "#31748f"
+yellow = "#f6c177"
+blue = "#9ccfd8"
+magenta = "#c4a7e7"
+cyan = "#ebbcba"
+white = "#e0def4"
+

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -35,6 +35,7 @@ require('lazy').setup({
   require 'plugins.neotree',
   require 'plugins.sleuth',
   require 'plugins.telescope',
+  require 'plugins.tmux-navigator',
   require 'plugins.treesitter',
   require 'plugins.trouble',
   require 'plugins.which-key',

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -35,6 +35,7 @@
   "tokyonight.nvim": { "branch": "main", "commit": "817bb6ffff1b9ce72cdd45d9fcfa8c9cd1ad3839" },
   "trouble.nvim": { "branch": "main", "commit": "6efc446226679fda0547c0fd6a7892fd5f5b15d8" },
   "vim-sleuth": { "branch": "master", "commit": "be69bff86754b1aa5adcbb527d7fcd1635a84080" },
+  "vim-tmux-navigator": { "branch": "master", "commit": "a9b52e7d36114d40350099f254b5f299a35df978" },
   "which-key.nvim": { "branch": "main", "commit": "fb070344402cfc662299d9914f5546d840a22126" },
   "yanky.nvim": { "branch": "main", "commit": "73215b77d22ebb179cef98e7e1235825431d10e4" }
 }

--- a/nvim/lua/options.lua
+++ b/nvim/lua/options.lua
@@ -65,3 +65,6 @@ vim.opt.scrolloff = 10
 
 -- Allow selecting whitespace in block editing mode
 vim.opt.virtualedit = 'block'
+
+-- Consider kebab-case as words
+vim.opt.iskeyword:append '-'

--- a/nvim/lua/options.lua
+++ b/nvim/lua/options.lua
@@ -26,6 +26,13 @@ vim.opt.undofile = true
 vim.opt.ignorecase = true
 vim.opt.smartcase = true
 
+-- Set up tabs for 2 char width, prefer spaces instead, auto-indent newlines
+vim.opt.shiftwidth = 2
+vim.opt.tabstop = 2
+vim.opt.softtabstop = 2
+vim.opt.expandtab = true
+vim.opt.smarttab = true
+
 -- Keep signcolumn on by default
 -- Allocate two columns to support staged and unstaged Git changes from gitsigns
 vim.opt.signcolumn = 'yes:2'

--- a/nvim/lua/options.lua
+++ b/nvim/lua/options.lua
@@ -19,6 +19,9 @@ end)
 -- Enable break indent
 vim.opt.breakindent = true
 
+-- Add visual columns for long lines
+vim.opt.colorcolumn = '80,120'
+
 -- Save undo history
 vim.opt.undofile = true
 

--- a/nvim/lua/plugins/tmux-navigator.lua
+++ b/nvim/lua/plugins/tmux-navigator.lua
@@ -1,0 +1,18 @@
+-- Integrate navigation between Neovim and Tmux panes
+return {
+  'christoomey/vim-tmux-navigator',
+  cmd = {
+    'TmuxNavigateLeft',
+    'TmuxNavigateDown',
+    'TmuxNavigateUp',
+    'TmuxNavigateRight',
+    'TmuxNavigatePrevious',
+  },
+  keys = {
+    { '<c-h>', '<cmd><C-U>TmuxNavigateLeft<cr>' },
+    { '<c-j>', '<cmd><C-U>TmuxNavigateDown<cr>' },
+    { '<c-k>', '<cmd><C-U>TmuxNavigateUp<cr>' },
+    { '<c-l>', '<cmd><C-U>TmuxNavigateRight<cr>' },
+    { '<c-\\>', '<cmd><C-U>TmuxNavigatePrevious<cr>' },
+  },
+}

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -23,3 +23,9 @@ bind -r k resize-pane -U 5
 bind -r l resize-pane -R 5
 bind -r h resize-pane -L 5
 bind -r m resize-pane -Z
+
+# Enable mouse mode
+set -g mouse on
+
+# Improve mouse visual selection
+unbind -T copy-mode-vi MouseDragEnd1Pane

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -36,3 +36,9 @@ set-window-option -g mode-keys vi
 # Visual and copy mode like on Vim
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'y' send -X copy-selection
+
+# Plugins
+set -g @plugin 'tmux-plugins/tpm' # TPM itself, must be cloned manually into ./plugins/tpm
+
+# Initialize TMUX plugin manager
+run '~/.config/tmux/plugins/tpm/tpm'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,0 +1,3 @@
+# Ensure the terminal uses the proper color mode
+set -g default-terminal "tmux-256color"
+set-option -ga terminal-overrides ",xterm-256color:Tc"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -41,6 +41,7 @@ bind-key -T copy-mode-vi 'y' send -X copy-selection
 set -g @plugin 'tmux-plugins/tpm' # TPM itself, must be cloned manually into ./plugins/tpm
 set -g @plugin 'tmux-plugins/tmux-resurrect' # Restores sessions after closing Tmux or shutting down the system
 set -g @plugin 'tmux-plugins/tmux-continuum' # Autosaves sessions for easier restoration
+set -g @plugin 'christoomey/vim-tmux-navigator' # Integrate navigation between Vim and Tmux panes
 
 # Plugin configuration
 set -g @resurrect-capture-pane-contents 'on' # Persist pane contents when restoring

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,3 +1,25 @@
 # Ensure the terminal uses the proper color mode
 set -g default-terminal "tmux-256color"
 set-option -ga terminal-overrides ",xterm-256color:Tc"
+
+# Rebind prefix
+set -g prefix C-a
+unbind C-b
+bind-key C-a send-prefix
+
+# Rebind config refresh
+unbind r
+bind r source-file ~/.config/tmux/tmux.conf
+
+# Rebind horizontal and vertical splits
+unbind %
+bind | split-window -h
+unbind '"'
+bind _ split-window -v
+
+# Bind pane resizing and maximizing
+bind -r j resize-pane -D 5
+bind -r k resize-pane -U 5
+bind -r l resize-pane -R 5
+bind -r h resize-pane -L 5
+bind -r m resize-pane -Z

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -29,3 +29,10 @@ set -g mouse on
 
 # Improve mouse visual selection
 unbind -T copy-mode-vi MouseDragEnd1Pane
+
+# Enable Vim motions
+set-window-option -g mode-keys vi
+
+# Visual and copy mode like on Vim
+bind-key -T copy-mode-vi 'v' send -X begin-selection
+bind-key -T copy-mode-vi 'y' send -X copy-selection

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -39,6 +39,12 @@ bind-key -T copy-mode-vi 'y' send -X copy-selection
 
 # Plugins
 set -g @plugin 'tmux-plugins/tpm' # TPM itself, must be cloned manually into ./plugins/tpm
+set -g @plugin 'tmux-plugins/tmux-resurrect' # Restores sessions after closing Tmux or shutting down the system
+set -g @plugin 'tmux-plugins/tmux-continuum' # Autosaves sessions for easier restoration
+
+# Plugin configuration
+set -g @resurrect-capture-pane-contents 'on' # Persist pane contents when restoring
+set -g @continuum-restore 'on' # Enable continuum
 
 # Initialize TMUX plugin manager
 run '~/.config/tmux/plugins/tpm/tpm'


### PR DESCRIPTION
Adds and configures the Alacritty terminal emulator and Tmux terminal multiplexer:
- Configures Alacritty with a cleaner look, custom font and custom color scheme
- Configures Tmux with more natural bindings and a custom color scheme
- Adds Tmux plugins for session resurrection and Vim navigation between panes

Closes #14 